### PR TITLE
Pin click typer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
 -   repo: https://github.com/python/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     - id: black
 -   repo: https://github.com/fsfe/reuse-tool

--- a/cascadetoml.py
+++ b/cascadetoml.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2021 Scott Shawcroft for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ requires = [
     "parse",
     "tabulate",
     "tomlkit>=0.8.0",
-    "typer"
+    "typer==0.4.0",
+    "click==8.0.4"
 ]
 
 [tool.flit.scripts]


### PR DESCRIPTION
click 8.1.0 is incompatible with typer. While there's an open PR to fix it in typer, we don't know when the fix will be released. So, just fix it by pinning known-compatible versions, including the transitive dependency we didn't explicitly list before.
 * https://github.com/tiangolo/typer/pull/375